### PR TITLE
Add QrCode + admin login protection via cookie

### DIFF
--- a/src/EventFeedbackApp.csproj
+++ b/src/EventFeedbackApp.csproj
@@ -12,6 +12,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="QRCoder" Version="1.6.0" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.5" />
   </ItemGroup>
 
 </Project>

--- a/src/EventFeedbackApp.csproj.user
+++ b/src/EventFeedbackApp.csproj.user
@@ -1,8 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ActiveDebugProfile>https</ActiveDebugProfile>
+    <ActiveDebugProfile>http</ActiveDebugProfile>
     <RazorPage_SelectedScaffolderID>RazorPageScaffolder</RazorPage_SelectedScaffolderID>
     <RazorPage_SelectedScaffolderCategoryPath>root/Common/RazorPage</RazorPage_SelectedScaffolderCategoryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
 </Project>

--- a/src/Middleware/AdminAuthMiddleware.cs
+++ b/src/Middleware/AdminAuthMiddleware.cs
@@ -1,0 +1,32 @@
+﻿namespace EventFeedbackApp.Middleware
+{
+    public class AdminAuthMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private const string AdminCookieName = "IsAdmin";
+
+        public AdminAuthMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            var path = context.Request.Path.Value;
+
+            if (path != null && path.StartsWith("/Admin", StringComparison.OrdinalIgnoreCase))
+            {
+                var isAdmin = context.Request.Cookies.TryGetValue(AdminCookieName, out var val) && val == "true";
+
+                if (!isAdmin && !path.Contains("/Admin/AdminLogin", StringComparison.OrdinalIgnoreCase))
+                {
+                    context.Response.Redirect("/Admin/AdminLogin");
+                    return;
+                }
+            }
+
+            await _next(context);
+        }
+    }
+
+}

--- a/src/Pages/Admin/AdminLogin.cshtml
+++ b/src/Pages/Admin/AdminLogin.cshtml
@@ -1,0 +1,20 @@
+﻿@page
+@model EventFeedbackApp.Pages.Admin.AdminLoginModel
+@{
+    ViewData["Title"] = "Admin Login";
+}
+
+<h2>Admin Login</h2>
+
+<form method="post">
+    <div class="mb-3">
+        <label for="Password">Passwort:</label>
+        <input type="password" asp-for="Password" class="form-control" />
+    </div>
+    <button type="submit" class="btn btn-primary">Login</button>
+</form>
+
+@if (!string.IsNullOrEmpty(Model.ErrorMessage))
+{
+    <div class="text-danger mt-2">@Model.ErrorMessage</div>
+}

--- a/src/Pages/Admin/AdminLogin.cshtml.cs
+++ b/src/Pages/Admin/AdminLogin.cshtml.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace EventFeedbackApp.Pages.Admin
+{
+    public class AdminLoginModel : PageModel
+    {
+        [BindProperty]
+        public string Password { get; set; }
+
+        public string ErrorMessage { get; set; }
+
+        public IActionResult OnPost()
+        {
+            if (Password == "DavidA123") // Admin-Passwort
+            {
+                Response.Cookies.Append("IsAdmin", "true", new CookieOptions
+                {
+                    HttpOnly = true,
+                    Secure = true,
+                    IsEssential = true,
+                    Expires = DateTimeOffset.UtcNow.AddHours(12)
+                });
+
+                return Redirect("/Admin/CreateSession");
+            }
+
+            ErrorMessage = "Falsches Passwort.";
+            return Page();
+        }
+    }
+}

--- a/src/Pages/Admin/CreateSession.cshtml
+++ b/src/Pages/Admin/CreateSession.cshtml
@@ -13,11 +13,20 @@
         <span asp-validation-for="Session.Title" class="text-danger"></span>
     </div>
     <button type="submit" class="btn btn-primary">Speichern</button>
-    @if (Request.Query.ContainsKey("saved"))
-    {
-        <div class="alert alert-success mt-3">Session angelegt!</div>
-    }
 </form>
+
+@if (Model.SessionSaved)
+{
+    <div class="alert alert-success mt-3">Session angelegt!</div>
+}
+
+@if (!string.IsNullOrEmpty(Model.QrCodeBase64))
+{
+    <div class="mt-4">
+        <h3>QR-Code zur Session:</h3>
+        <img src="@Model.QrCodeBase64" alt="QR Code" style="width: 200px;" />
+    </div>
+}
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/src/Pages/Admin/CreateSession.cshtml.cs
+++ b/src/Pages/Admin/CreateSession.cshtml.cs
@@ -1,26 +1,55 @@
-using EventFeedbackApp.Data;
+﻿using EventFeedbackApp.Data;
 using EventFeedbackApp.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Configuration;
+using QRCoder;
 
 namespace EventFeedbackApp.Pages.Admin
 {
     public class CreateSessionModel : PageModel
     {
         private readonly AppDbContext _db;
-        public CreateSessionModel(AppDbContext db) => _db = db;
+        private readonly IConfiguration _config;
+
+        public CreateSessionModel(AppDbContext db, IConfiguration config)
+        {
+            _db = db;
+            _config = config;
+        }
 
         [BindProperty]
         public Session Session { get; set; } = new();
+
+        public string QrCodeBase64 { get; set; }
+
+        public bool SessionSaved { get; set; } = false;
 
         public void OnGet() { }
 
         public async Task<IActionResult> OnPostAsync()
         {
-            if (!ModelState.IsValid) return Page();
+            if (!ModelState.IsValid)
+                return Page();
+
             _db.Sessions.Add(Session);
             await _db.SaveChangesAsync();
-            return RedirectToPage("/Admin/CreateSession", new { saved = true });
+            SessionSaved = true;
+
+            // Nutze die BaseUrl aus der Konfiguration (z. B. ngrok-Adresse)
+            string baseUrl = _config["App:BaseUrl"];
+            string sessionUrl = $"{baseUrl}/Feedback/JoinSession?sessionId={Session.Id}";
+
+            using var qrGenerator = new QRCodeGenerator();
+            QRCodeData qrCodeData = qrGenerator.CreateQrCode(sessionUrl, QRCodeGenerator.ECCLevel.Q);
+            var svgQrCode = new SvgQRCode(qrCodeData);
+            string svgImage = svgQrCode.GetGraphic(5);
+
+            var svgBytes = System.Text.Encoding.UTF8.GetBytes(svgImage);
+            var base64Svg = Convert.ToBase64String(svgBytes);
+            QrCodeBase64 = $"data:image/svg+xml;base64,{base64Svg}";
+
+            return Page(); // Zeige das QR-Bild an
         }
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using EventFeedbackApp.Data;
 using EventFeedbackApp.Hubs;
+using EventFeedbackApp.Middleware;
 using EventFeedbackApp.Models;
 using Microsoft.EntityFrameworkCore;
 
@@ -55,6 +56,8 @@ if (!app.Environment.IsDevelopment())
 // app.UseHttpsRedirection();
 app.UseStaticFiles();
 app.UseRouting();
+app.UseMiddleware<AdminAuthMiddleware>();
+
 
 // 6) Endpoints
 

--- a/src/Properties/launchSettings.json
+++ b/src/Properties/launchSettings.json
@@ -13,19 +13,11 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "http://localhost:5136",
+      "applicationUrl": "http://localhost:8034",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
-    },
-    "https": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "https://localhost:7225;http://localhost:5136",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+    }
     },
     "IIS Express": {
       "commandName": "IISExpress",

--- a/src/appsettings.Development.json
+++ b/src/appsettings.Development.json
@@ -1,4 +1,8 @@
 {
+  "App": {
+    "BaseUrl": "https://383e-178-38-5-163.ngrok-free.app" //Change the URL every time you restart ngrok
+  },
+
   "DetailedErrors": true,
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Introduced middleware to restrict access to all /Admin routes. Users must enter the correct password once, which sets a secure cookie ("IsAdmin=true"). All admin pages check this cookie automatically.

Includes:
- AdminLogin page with password form
- Middleware for global admin route protection
- Cookie-based access management